### PR TITLE
Updated controls to include diagonal movement and decreased sensitivity.

### DIFF
--- a/PVSNES/PVSNES/SNES/PVSNESEmulatorCore.mm
+++ b/PVSNES/PVSNES/SNES/PVSNESEmulatorCore.mm
@@ -402,10 +402,17 @@ static void FinalizeSamplesAudioCallback(void *)
 
             PVControllerAxisDirection axisDirection = [PVGameControllerUtilities axisDirectionForThumbstick:pad.leftThumbstick];
 
-            S9xReportButton(playerMask | PVSNESButtonUp, dpad.up.pressed ?: axisDirection == PVControllerAxisDirectionUp);
-            S9xReportButton(playerMask | PVSNESButtonDown, dpad.down.pressed ?: axisDirection == PVControllerAxisDirectionDown);
-            S9xReportButton(playerMask | PVSNESButtonLeft, dpad.left.pressed ?: axisDirection == PVControllerAxisDirectionLeft);
-            S9xReportButton(playerMask | PVSNESButtonRight, dpad.right.pressed ?: axisDirection == PVControllerAxisDirectionRight);
+            BOOL upPressed = dpad.up.pressed || axisDirection == PVControllerAxisDirectionUp || axisDirection == PVControllerAxisDirectionUpLeft || axisDirection == PVControllerAxisDirectionUpRight;
+            S9xReportButton(playerMask | PVSNESButtonUp, upPressed);
+            
+            BOOL downPressed = dpad.down.pressed || axisDirection == PVControllerAxisDirectionDown || axisDirection == PVControllerAxisDirectionDownLeft || axisDirection == PVControllerAxisDirectionDownRight;
+            S9xReportButton(playerMask | PVSNESButtonDown, downPressed);
+            
+            BOOL leftPressed = dpad.left.pressed || axisDirection == PVControllerAxisDirectionLeft || axisDirection == PVControllerAxisDirectionUpLeft || axisDirection == PVControllerAxisDirectionDownLeft;
+            S9xReportButton(playerMask | PVSNESButtonLeft, leftPressed);
+            
+            BOOL rightPressed = dpad.right.pressed || axisDirection == PVControllerAxisDirectionRight || axisDirection == PVControllerAxisDirectionUpRight || axisDirection == PVControllerAxisDirectionDownRight;
+            S9xReportButton(playerMask | PVSNESButtonRight, rightPressed);
 
             S9xReportButton(playerMask | PVSNESButtonB, pad.buttonA.pressed);
             S9xReportButton(playerMask | PVSNESButtonA, pad.buttonB.pressed);

--- a/PVSupport/PVSupport/PVGameControllerUtilities.h
+++ b/PVSupport/PVSupport/PVGameControllerUtilities.h
@@ -13,7 +13,11 @@ typedef NS_ENUM(NSUInteger, PVControllerAxisDirection) {
     PVControllerAxisDirectionUp,
     PVControllerAxisDirectionDown,
     PVControllerAxisDirectionLeft,
-    PVControllerAxisDirectionRight
+    PVControllerAxisDirectionRight,
+    PVControllerAxisDirectionUpRight,
+    PVControllerAxisDirectionUpLeft,
+    PVControllerAxisDirectionDownRight,
+    PVControllerAxisDirectionDownLeft
 };
 
 @interface PVGameControllerUtilities : NSObject

--- a/PVSupport/PVSupport/PVGameControllerUtilities.m
+++ b/PVSupport/PVSupport/PVGameControllerUtilities.m
@@ -13,21 +13,39 @@
 @implementation PVGameControllerUtilities
 
 + (PVControllerAxisDirection)axisDirectionForThumbstick:(GCControllerDirectionPad *)thumbstick {
-    static CGFloat thumbstickSensitivty = 0.1;
-    BOOL isXAxis = (fabsf(thumbstick.xAxis.value) > fabsf(thumbstick.yAxis.value));
-    if (!isXAxis && thumbstick.yAxis.value >= thumbstickSensitivty) {
-        return PVControllerAxisDirectionUp;
+    static CGFloat thumbstickSensitivty = 0.2;
+        
+    if (fabsf(thumbstick.xAxis.value) <= thumbstickSensitivty && fabsf(thumbstick.yAxis.value) <= thumbstickSensitivty) {
+        return PVControllerAxisDirectionNone;
     }
-    if (!isXAxis && thumbstick.yAxis.value <= -thumbstickSensitivty) {
-        return PVControllerAxisDirectionDown;
-    }
-    if (isXAxis && thumbstick.xAxis.value <= -thumbstickSensitivty) {
+    
+    float angle = atan2f(thumbstick.yAxis.value, thumbstick.xAxis.value);
+
+    if (angle >= 7 * M_PI / 8 || angle <= -7 * M_PI / 8) {
         return PVControllerAxisDirectionLeft;
     }
-    if (isXAxis && thumbstick.xAxis.value >= thumbstickSensitivty) {
-        return PVControllerAxisDirectionRight;
+    
+    if (angle > 5 * M_PI / 8) {
+        return PVControllerAxisDirectionUpLeft;
     }
-    return PVControllerAxisDirectionNone;
+    if (angle >= 3 * M_PI / 8) {
+        return PVControllerAxisDirectionUp;
+    }
+    if (angle > 1 * M_PI / 8) {
+        return PVControllerAxisDirectionUpRight;
+    }
+    
+    if (angle < -5 * M_PI / 8) {
+        return PVControllerAxisDirectionDownLeft;
+    }
+    if (angle <= -3 * M_PI / 8) {
+        return PVControllerAxisDirectionDown;
+    }
+    if (angle < -1 * M_PI / 8) {
+        return PVControllerAxisDirectionDownRight;
+    }
+    
+    return PVControllerAxisDirectionRight;
 }
 
 @end


### PR DESCRIPTION
I've tested this with all my SNES games and they all work great with the analog stick now.

The code works by dividing the unit circle into 8 sectors. Each sector is π / 4 radians wide. The sectors are positioned so that each of the 8 directions is in the middle of each sector. So the sector for direction Right is not [0, π / 4], but [-π / 8, π / 8], and so on.

The x and y values of the analog stick are used to calculate the angle the stick is in (y / x = arcus tangens). The angle is expressed in radians, between π and -π. The code compares this angle to the boundaries of each sector to see which sector the angle is in.

Finally, the SNES code has been modified to take the diagonal directions into account.
